### PR TITLE
Add isOnACoin(), isOnAnotherRobot() + deprecate isNextToACoin(), isNextToARobot()

### DIFF
--- a/src/main/java/fopbot/Robot.java
+++ b/src/main/java/fopbot/Robot.java
@@ -325,7 +325,7 @@ public class Robot extends FieldEntity {
    * the same position as the robot's position
    * @deprecated Confusing name, use {@link #isOnACoin()} instead.
    */
-  @Deprecated(since = "0.3.0", forRemoval = true)
+  @Deprecated(since = "0.3.0")
   public boolean isNextToACoin() {
     return isOnACoin();
   }
@@ -342,7 +342,7 @@ public class Robot extends FieldEntity {
    * position
    * @deprecated Confusing name, use {@link #isOnAnotherRobot()} instead.
    */
-  @Deprecated(since = "0.3.0", forRemoval = true)
+  @Deprecated(since = "0.3.0")
   public boolean isNextToARobot() {
     return isOnAnotherRobot();
   }

--- a/src/main/java/fopbot/Robot.java
+++ b/src/main/java/fopbot/Robot.java
@@ -316,16 +316,35 @@ public class Robot extends FieldEntity {
    * @return true if the robot is standing on a coin/if at least one coin is at
    * the same position as the robot's position
    */
-  public boolean isNextToACoin() {
+  public boolean isOnACoin() {
     return world.isCoinInField(getX(), getY());
+  }
+
+  /**
+   * @return true if the robot is standing on a coin/if at least one coin is at
+   * the same position as the robot's position
+   * @deprecated Confusing name, use {@link #isOnACoin()} instead.
+   */
+  @Deprecated(since = "0.3.0", forRemoval = true)
+  public boolean isNextToACoin() {
+    return isOnACoin();
+  }
+
+  /**
+   * @return true if at least another robot is at the same position as the robot's position
+   */
+  public boolean isOnAnotherRobot() {
+    return world.isAnotherRobotInField(getX(), getY(), this);
   }
 
   /**
    * @return true if at least another robot is at the same position as the robot's
    * position
+   * @deprecated Confusing name, use {@link #isOnAnotherRobot()} instead.
    */
+  @Deprecated(since = "0.3.0", forRemoval = true)
   public boolean isNextToARobot() {
-    return world.isAnotherRobotInField(getX(), getY(), this);
+    return isOnAnotherRobot();
   }
 
   /**


### PR DESCRIPTION
Replaces the methods:
1. `isNextToACoin()` -> `isOnACoin()`
2. `isNextToARobot()` -> `isOnAnotherRobot()`

Note: `isNextToACoin()` and `isNextToARobot()` will continue to be available (for now) but marked as deprecated.